### PR TITLE
Remove hardcoded version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "onesky/api-library-php5",
-    "version": "1.0.3",
     "description": "PHP interface for OneSky Platform API",
     "type": "library",
     "require-dev": {


### PR DESCRIPTION
Hey,

You don't need version in `composer.json`, it mislead. Composer will automatically take version from git tags.

https://getcomposer.org/doc/02-libraries.md#specifying-the-version